### PR TITLE
libsacloudからの移植 - newsfeed

### DIFF
--- a/newsfeed/functions.go
+++ b/newsfeed/functions.go
@@ -1,0 +1,54 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package newsfeed
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+// NewsFeedURL フィード取得URL
+var NewsFeedURL = "https://secure.sakura.ad.jp/rss/sakuranews/getfeeds.php?format=json"
+
+// Get ニュースフィード(障害/メンテナンス情報)を取得
+func Get() (FeedItems, error) {
+	resp, err := http.Get(NewsFeedURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var items []*FeedItem
+	if err := json.Unmarshal(data, &items); err != nil {
+		return nil, err
+	}
+
+	return items, nil
+}
+
+// GetByURL 指定のURLを持つフィードを取得
+func GetByURL(url string) (*FeedItem, error) {
+	items, err := Get()
+	if err != nil {
+		return nil, err
+	}
+	return items.ByURL(url), nil
+}

--- a/newsfeed/functions_test.go
+++ b/newsfeed/functions_test.go
@@ -1,0 +1,36 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build acctest
+// +build acctest
+
+package newsfeed
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGet(t *testing.T) {
+	items, err := Get()
+	require.NoError(t, err)
+	require.True(t, len(items) > 0)
+	fetched := items[0]
+
+	// by URL
+	item, err := GetByURL(fetched.URL)
+	require.NoError(t, err)
+	require.Equal(t, fetched, item)
+}

--- a/newsfeed/newsfeed.go
+++ b/newsfeed/newsfeed.go
@@ -1,0 +1,63 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package newsfeed
+
+import (
+	"strconv"
+	"time"
+)
+
+// FeedItems メンテナンス/障害情報お知らせ
+type FeedItems []*FeedItem
+
+// ByURL 指定のURLを持つFeedItemを返す
+func (items *FeedItems) ByURL(url string) *FeedItem {
+	for _, item := range *items {
+		if item.URL == url {
+			return item
+		}
+	}
+	return nil
+}
+
+// FeedItem メンテナンス/障害情報お知らせ(個別)
+type FeedItem struct {
+	StrDate       string `json:"date,omitempty"`
+	Description   string `json:"desc,omitempty"`
+	StrEventStart string `json:"event_start,omitempty"`
+	StrEventEnd   string `json:"event_end,omitempty"`
+	Title         string `json:"title,omitempty"`
+	URL           string `json:"url,omitempty"`
+}
+
+// Date 対象日時
+func (f *FeedItem) Date() time.Time {
+	return f.parseTime(f.StrDate)
+}
+
+// EventStart 掲載開始日時
+func (f *FeedItem) EventStart() time.Time {
+	return f.parseTime(f.StrEventStart)
+}
+
+// EventEnd 掲載終了日時
+func (f *FeedItem) EventEnd() time.Time {
+	return f.parseTime(f.StrEventEnd)
+}
+
+func (f *FeedItem) parseTime(sec string) time.Time {
+	s, _ := strconv.ParseInt(sec, 10, 64)
+	return time.Unix(s, 0)
+}


### PR DESCRIPTION
newsfeedパッケージの移植

- フィード取得時のクエリストリングから`service=cloud`を除去(クラウド以外でも使用するため)
- URL指定でフィードアイテム取得する際に毎回フィードを参照しなくても済むようにヘルパーを追加