### PR TITLE
pkg: waitパッケージ

### DIFF
--- a/pkg/wait/polling.go
+++ b/pkg/wait/polling.go
@@ -1,0 +1,137 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wait
+
+import (
+	"context"
+	"time"
+)
+
+var (
+	defaultPollingTimeout  = 20 * time.Minute
+	defaultPollingInterval = 5 * time.Second
+)
+
+// StateReadFunc PollingWaiterにより利用される、対象リソースの状態を取得するためのfunc
+type StateReadFunc func() (state interface{}, err error)
+
+// StateCheckFunc StateReadFuncで得たリソースの情報を元に待ちを継続するか判定するためのfunc
+//
+// completeがtrueの場合待ち処理を終了する
+type StateCheckFunc func(target interface{}) (complete bool, err error)
+
+// PollingWaiter ポーリングでステート変更を検知するWaiter
+type PollingWaiter struct {
+	// ReadFunc 対象リソースの状態を取得するためのfunc
+	ReadFunc StateReadFunc
+
+	// StateCheckFunc ReadFuncで得たリソースの情報を元に待ちを継続するかの判定を行うためのfunc
+	StateCheckFunc StateCheckFunc
+
+	// Timeout タイムアウト
+	Timeout time.Duration // タイムアウト
+
+	// Interval ポーリング間隔
+	Interval time.Duration
+}
+
+// WaitForState リソースが指定の状態になるまで待つ
+func (w *PollingWaiter) WaitForState(ctx context.Context) (interface{}, error) {
+	c, p, e := w.WaitForStateAsync(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case lastState := <-c:
+			return lastState, nil
+		case <-p:
+			// noop
+		case err := <-e:
+			return nil, err
+		}
+	}
+}
+
+// WaitForStateAsync リソースが指定の状態になるまで待つ
+func (w *PollingWaiter) WaitForStateAsync(ctx context.Context) (<-chan interface{}, <-chan interface{}, <-chan error) {
+	w.validateFields()
+	w.defaults()
+
+	compCh := make(chan interface{})
+	progressCh := make(chan interface{})
+	errCh := make(chan error)
+
+	ticker := time.NewTicker(w.Interval)
+
+	go func() {
+		ctx, cancel := context.WithTimeout(ctx, w.Timeout)
+		defer cancel()
+
+		defer ticker.Stop()
+
+		defer close(compCh)
+		defer close(progressCh)
+		defer close(errCh)
+
+		for {
+			select {
+			case <-ctx.Done():
+				errCh <- ctx.Err()
+				return
+			case <-ticker.C:
+				state, err := w.ReadFunc()
+				if err != nil {
+					errCh <- err
+					return
+				}
+
+				complete, err := w.StateCheckFunc(state)
+				if complete {
+					compCh <- state
+					return
+				}
+
+				if err != nil {
+					errCh <- err
+					return
+				}
+
+				// note: nilの場合もあり得る
+				progressCh <- state
+			}
+		}
+	}()
+
+	return compCh, progressCh, errCh
+}
+
+func (w *PollingWaiter) validateFields() {
+	if w.ReadFunc == nil {
+		panic("required: PollingWaiter.ReadFunc")
+	}
+
+	if w.StateCheckFunc == nil {
+		panic("required: PollingWaiter.StateCheckFunc")
+	}
+}
+
+func (w *PollingWaiter) defaults() {
+	if w.Timeout == time.Duration(0) {
+		w.Timeout = defaultPollingTimeout
+	}
+	if w.Interval == time.Duration(0) {
+		w.Interval = defaultPollingInterval
+	}
+}

--- a/pkg/wait/waiter.go
+++ b/pkg/wait/waiter.go
@@ -1,0 +1,27 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wait
+
+import (
+	"context"
+)
+
+// StateWaiter リソースの状態が変わるまで待機する
+type StateWaiter interface {
+	// WaitForState リソースが指定の状態になるまで待つ
+	WaitForState(context.Context) (interface{}, error)
+	// WaitForStateAsync リソースが指定の状態になるまで待つ(非同期)
+	WaitForStateAsync(context.Context) (completeCh <-chan interface{}, progressCh <-chan interface{}, errorCh <-chan error)
+}

--- a/pkg/wait/waiter_test.go
+++ b/pkg/wait/waiter_test.go
@@ -1,0 +1,76 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wait
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type dummyState struct {
+	state interface{}
+	err   error
+}
+
+func testStateCheckFunc(target interface{}) (bool, error) {
+	state, ok := target.(*dummyState)
+	if !ok {
+		return false, fmt.Errorf("got invalid state type: %+v", target)
+	}
+	return state.state != nil, state.err
+}
+
+func TestStatePollingWaiter_withStateCheckFunc(t *testing.T) {
+	t.Run("timeout", func(t *testing.T) {
+		waiter := &PollingWaiter{
+			ReadFunc: func() (interface{}, error) {
+				return &dummyState{}, nil
+			},
+			StateCheckFunc: testStateCheckFunc,
+			Timeout:        5 * time.Millisecond,
+			Interval:       1 * time.Millisecond,
+		}
+		ctx := context.Background()
+		_, err := waiter.WaitForState(ctx)
+		require.Error(t, err)
+		require.EqualError(t, err, "context deadline exceeded")
+	})
+
+	t.Run("parent context was canceled", func(t *testing.T) {
+		waiter := &PollingWaiter{
+			ReadFunc: func() (interface{}, error) {
+				return &dummyState{}, nil
+			},
+			StateCheckFunc: testStateCheckFunc,
+			Timeout:        100 * time.Millisecond,
+			Interval:       1 * time.Millisecond,
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		_, err := waiter.WaitForState(ctx)
+		go func() {
+			time.Sleep(5 * time.Millisecond)
+			cancel()
+		}()
+
+		require.Error(t, err)
+		require.EqualError(t, err, "context deadline exceeded")
+	})
+}


### PR DESCRIPTION
libsacloud/v2/sacloudのStateWaiterを切り出し

抽象化しIaaS依存部分を除いた形で切り出している。
依存部分はそれぞれのライブラリ側で実装する。