### PR TITLE
pkg/wait: 複数のStateCheckFuncへの対応

### DIFF
--- a/pkg/wait/polling.go
+++ b/pkg/wait/polling.go
@@ -32,6 +32,24 @@ type StateReadFunc func() (state interface{}, err error)
 // completeがtrueの場合待ち処理を終了する
 type StateCheckFunc func(target interface{}) (complete bool, err error)
 
+// ComposeStateCheckFunc 指定のStateCheckFuncを順に適用するするStateCheckFuncを生成する
+//
+// completeがtrueまたはerrが非nilになったら即時リターンする。
+func ComposeStateCheckFunc(funcs ...StateCheckFunc) StateCheckFunc {
+	return func(target interface{}) (bool, error) {
+		for _, f := range funcs {
+			complete, err := f(target)
+			if err != nil {
+				return false, err
+			}
+			if complete {
+				return complete, nil
+			}
+		}
+		return false, nil
+	}
+}
+
 // PollingWaiter ポーリングでステート変更を検知するWaiter
 type PollingWaiter struct {
 	// ReadFunc 対象リソースの状態を取得するためのfunc


### PR DESCRIPTION
wait.StateCheckFuncを細分化し組み合わせて使うために、複数のStateCheckFuncを1つにまとめるfuncを追加する。

この実装は複数のStateCheckFuncの呼び出し結果のORを取る。ANDは現状不要な想定で、必要になったタイミングで実装する。