### PR TITLE
libsacloudからsetupパッケージの移植

### DIFF
--- a/service/iaas/setup/options.go
+++ b/service/iaas/setup/options.go
@@ -1,0 +1,84 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package setup
+
+import "time"
+
+var (
+	//	DefaultNICUpdateWaitDuration デフォルトのNIC更新待ち
+	DefaultNICUpdateWaitDuration = 5 * time.Second
+
+	// DefaultMaxRetryCount デフォルトリトライ最大数
+	DefaultMaxRetryCount = 3
+
+	// DefaultProvisioningRetryCount リソースごとのプロビジョニングAPI呼び出しのリトライ最大数
+	DefaultProvisioningRetryCount = 10
+
+	// DefaultProvisioningWaitInterval リソースごとのプロビジョニングAPI呼び出しのリトライ間隔
+	DefaultProvisioningWaitInterval = 5 * time.Second
+
+	// DefaultDeleteRetryCount リソースごとの削除API呼び出しのリトライ最大数
+	DefaultDeleteRetryCount = 10
+
+	// DefaultDeleteWaitInterval リソースごとの削除API呼び出しのリトライ間隔
+	DefaultDeleteWaitInterval = 10 * time.Second
+
+	// DefaultPollingInterval ポーリング処理の間隔
+	DefaultPollingInterval = 5 * time.Second
+)
+
+// Options アプライアンス作成時に利用するsetup.RetryableSetupのパラメータ
+type Options struct {
+	// BootAfterBuild Buildの後に再起動を行うか
+	BootAfterBuild bool
+	// NICUpdateWaitDuration NIC接続切断操作の後の待ち時間
+	NICUpdateWaitDuration time.Duration
+	// RetryCount リトライ回数
+	RetryCount int
+	// ProvisioningRetryCount リトライ回数
+	ProvisioningRetryCount int
+	// ProvisioningRetryInterval
+	ProvisioningRetryInterval time.Duration
+	// DeleteRetryCount 削除リトライ回数
+	DeleteRetryCount int
+	// DeleteRetryInterval 削除リトライ間隔
+	DeleteRetryInterval time.Duration
+	// sacloud.StateWaiterによるステート待ちの間隔
+	PollingInterval time.Duration
+}
+
+func (o *Options) init() {
+	if o.NICUpdateWaitDuration == time.Duration(0) {
+		o.NICUpdateWaitDuration = DefaultNICUpdateWaitDuration
+	}
+	if o.RetryCount <= 0 {
+		o.RetryCount = DefaultMaxRetryCount
+	}
+	if o.DeleteRetryCount <= 0 {
+		o.DeleteRetryCount = DefaultDeleteRetryCount
+	}
+	if o.DeleteRetryInterval <= 0 {
+		o.DeleteRetryInterval = DefaultDeleteWaitInterval
+	}
+	if o.ProvisioningRetryCount <= 0 {
+		o.ProvisioningRetryCount = DefaultProvisioningRetryCount
+	}
+	if o.ProvisioningRetryInterval <= 0 {
+		o.ProvisioningRetryInterval = DefaultProvisioningWaitInterval
+	}
+	if o.PollingInterval <= 0 {
+		o.PollingInterval = DefaultPollingInterval
+	}
+}

--- a/service/iaas/setup/retryable_setup.go
+++ b/service/iaas/setup/retryable_setup.go
@@ -1,0 +1,245 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package setup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/accessor"
+	"github.com/sacloud/iaas-api-go/types"
+)
+
+// MaxRetryCountExceededError リトライ最大数超過エラー
+type MaxRetryCountExceededError error
+
+// CreateFunc リソース作成関数
+type CreateFunc func(ctx context.Context, zone string) (accessor.ID, error)
+
+// ProvisionBeforeUpFunc リソース作成後、起動前のプロビジョニング関数
+//
+// リソース作成後に起動が行われないリソース(VPCルータなど)向け。
+// 必要であればこの中でリソース起動処理を行う。
+type ProvisionBeforeUpFunc func(ctx context.Context, zone string, id types.ID, target interface{}) error
+
+// DeleteFunc リソース削除関数。
+//
+// リソース作成時のコピー待ちの間にリソースのAvailabilityがFailedになった場合に利用される。
+type DeleteFunc func(ctx context.Context, zone string, id types.ID) error
+
+// ReadFunc リソース起動待ちなどで利用するリソースのRead用Func
+type ReadFunc func(ctx context.Context, zone string, id types.ID) (interface{}, error)
+
+// RetryableSetup リソース作成時にコピー待ちや起動待ちが必要なリソースのビルダー。
+//
+// リソースのビルドの際、必要に応じてリトライ(リソースの削除&再作成)を行う。
+type RetryableSetup struct {
+	// Create リソース作成用関数
+	Create CreateFunc
+	// IsWaitForCopy コピー待ちを行うか
+	IsWaitForCopy bool
+	// IsWaitForUp 起動待ちを行うか
+	IsWaitForUp bool
+	// ProvisionBeforeUp リソース起動前のプロビジョニング関数
+	ProvisionBeforeUp ProvisionBeforeUpFunc
+	// Delete リソース削除用関数
+	Delete DeleteFunc
+	// Read リソース起動待ち関数
+	Read ReadFunc
+
+	// Options .
+	Options *Options
+}
+
+// Setup リソースのビルドを行う。必要に応じてリトライ(リソースの削除&再作成)を行う。
+func (r *RetryableSetup) Setup(ctx context.Context, zone string) (interface{}, error) {
+	if (r.IsWaitForCopy || r.IsWaitForUp) && r.Read == nil {
+		return nil, errors.New("failed: Read is required when IsWaitForCopy or IsWaitForUp is true")
+	}
+
+	r.init()
+
+	var created interface{}
+	for r.Options.RetryCount+1 > 0 {
+		r.Options.RetryCount--
+
+		// リソース作成
+		target, err := r.createResource(ctx, zone)
+		if err != nil {
+			return nil, err
+		}
+		id := target.GetID()
+
+		// コピー待ち
+		if r.IsWaitForCopy {
+			// コピー待ち、Failedになった場合はリソース削除
+			state, err := r.waitForCopyWithCleanup(ctx, zone, id)
+			if err != nil {
+				return state, err
+			}
+			if state != nil {
+				created = state
+			}
+		} else {
+			created = target
+		}
+
+		// 起動前の設定など
+		if err := r.provisionBeforeUp(ctx, zone, id, created); err != nil {
+			return created, err
+		}
+
+		// 起動待ち
+		if err := r.waitForUp(ctx, zone, id, created); err != nil {
+			return created, err
+		}
+
+		if created != nil {
+			break
+		}
+	}
+
+	if created == nil {
+		return nil, MaxRetryCountExceededError(fmt.Errorf("max retry count exceeded"))
+	}
+	return created, nil
+}
+
+func (r *RetryableSetup) init() {
+	if r.Options == nil {
+		r.Options = &Options{}
+	}
+	r.Options.init()
+}
+
+func (r *RetryableSetup) createResource(ctx context.Context, zone string) (accessor.ID, error) {
+	if r.Create == nil {
+		return nil, fmt.Errorf("create func is required")
+	}
+	return r.Create(ctx, zone)
+}
+
+func (r *RetryableSetup) waitForCopyWithCleanup(ctx context.Context, zone string, id types.ID) (interface{}, error) {
+	waiter := &iaas.StatePollingWaiter{
+		ReadFunc: func() (interface{}, error) {
+			return r.Read(ctx, zone, id)
+		},
+		TargetAvailability: []types.EAvailability{
+			types.Availabilities.Available,
+			types.Availabilities.Failed,
+		},
+		PendingAvailability: []types.EAvailability{
+			types.Availabilities.Unknown,
+			types.Availabilities.Migrating,
+			types.Availabilities.Uploading,
+			types.Availabilities.Transferring,
+			types.Availabilities.Discontinued,
+		},
+		Interval: r.Options.PollingInterval,
+	}
+
+	//wait
+	compChan, progressChan, errChan := waiter.WaitForStateAsync(ctx)
+	var state interface{}
+	var err error
+
+loop:
+	for {
+		select {
+		case v := <-compChan:
+			state = v
+			break loop
+		case v := <-progressChan:
+			state = v
+		case e := <-errChan:
+			err = e
+			break loop
+		}
+	}
+
+	if state != nil {
+		// Availabilityを持ち、Failedになっていた場合はリソースを削除してリトライ
+		if f, ok := state.(accessor.Availability); ok && f != nil {
+			if f.GetAvailability().IsFailed() {
+				// FailedになったばかりだとDelete APIが失敗する(コピー進行中など)場合があるため、
+				// 任意の回数リトライ&待機を行う
+				for i := 0; i < r.Options.DeleteRetryCount; i++ {
+					time.Sleep(r.Options.DeleteRetryInterval)
+					if err = r.Delete(ctx, zone, id); err == nil {
+						break
+					}
+				}
+
+				return nil, nil
+			}
+		}
+
+		return state, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func (r *RetryableSetup) provisionBeforeUp(ctx context.Context, zone string, id types.ID, created interface{}) error {
+	if r.ProvisionBeforeUp != nil && created != nil {
+		var err error
+		for i := 0; i < r.Options.ProvisioningRetryCount; i++ {
+			if err = r.ProvisionBeforeUp(ctx, zone, id, created); err == nil {
+				break
+			}
+			time.Sleep(r.Options.ProvisioningRetryInterval)
+		}
+		return err
+	}
+	return nil
+}
+
+func (r *RetryableSetup) waitForUp(ctx context.Context, zone string, id types.ID, created interface{}) error {
+	if r.IsWaitForUp && created != nil {
+		waiter := &iaas.StatePollingWaiter{
+			ReadFunc: func() (interface{}, error) {
+				return r.Read(ctx, zone, id)
+			},
+			TargetAvailability: []types.EAvailability{
+				types.Availabilities.Available,
+			},
+			PendingAvailability: []types.EAvailability{
+				types.Availabilities.Unknown,
+				types.Availabilities.Migrating,
+				types.Availabilities.Uploading,
+				types.Availabilities.Transferring,
+				types.Availabilities.Discontinued,
+			},
+			TargetInstanceStatus: []types.EServerInstanceStatus{
+				types.ServerInstanceStatuses.Up,
+			},
+			PendingInstanceStatus: []types.EServerInstanceStatus{
+				types.ServerInstanceStatuses.Unknown,
+				types.ServerInstanceStatuses.Cleaning,
+				types.ServerInstanceStatuses.Down,
+			},
+			Interval: r.Options.PollingInterval,
+		}
+		_, err := waiter.WaitForState(ctx)
+		return err
+	}
+	return nil
+}

--- a/service/iaas/setup/retryable_setup_test.go
+++ b/service/iaas/setup/retryable_setup_test.go
@@ -1,0 +1,167 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package setup
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/sacloud/iaas-api-go/accessor"
+	"github.com/sacloud/iaas-api-go/types"
+	"github.com/stretchr/testify/require"
+)
+
+type dummyIDAccessor struct {
+	id types.ID
+}
+
+func (d *dummyIDAccessor) GetID() types.ID {
+	return d.id
+}
+
+func (d *dummyIDAccessor) SetID(id types.ID) {
+	d.id = id
+}
+
+type dummyAvailabilityAccessor struct {
+	available types.EAvailability
+}
+
+func (d *dummyAvailabilityAccessor) GetAvailability() types.EAvailability {
+	return d.available
+}
+
+func (d *dummyAvailabilityAccessor) SetAvailability(a types.EAvailability) {
+	d.available = a
+}
+
+func TestRetryableSetup_Setup(t *testing.T) {
+	ctx := context.Background()
+	zone := "tk1v"
+
+	t.Run("create", func(t *testing.T) {
+		t.Run("no error", func(t *testing.T) {
+			retryable := &RetryableSetup{
+				Create: func(context.Context, string) (id accessor.ID, e error) {
+					return &dummyIDAccessor{id: 1}, nil
+				},
+				Read: func(ctx context.Context, zone string, id types.ID) (interface{}, error) {
+					return &dummyIDAccessor{id: 1}, nil
+				},
+				Options: &Options{
+					ProvisioningRetryInterval: time.Millisecond,
+					DeleteRetryInterval:       time.Millisecond,
+					PollingInterval:           time.Millisecond,
+				},
+			}
+			res, err := retryable.Setup(ctx, zone)
+
+			require.NotNil(t, res)
+			require.NoError(t, err)
+			_, ok := res.(accessor.ID)
+			require.True(t, ok)
+		})
+
+		t.Run("error", func(t *testing.T) {
+			retryable := &RetryableSetup{
+				Create: func(context.Context, string) (accessor.ID, error) {
+					return nil, fmt.Errorf("error")
+				},
+				Read: func(ctx context.Context, zone string, id types.ID) (interface{}, error) {
+					return &dummyIDAccessor{id: 1}, nil
+				},
+				Options: &Options{
+					ProvisioningRetryInterval: time.Millisecond,
+					DeleteRetryInterval:       time.Millisecond,
+					PollingInterval:           time.Millisecond,
+				},
+			}
+			res, err := retryable.Setup(ctx, zone)
+
+			require.Nil(t, res)
+			require.Error(t, err)
+		})
+	})
+	//
+	t.Run("Retry", func(t *testing.T) {
+		t.Run("retry under max count", func(t *testing.T) {
+			// リトライ3回、ReadFuncは3回呼ばれるまではFailedが返る(4回目以降はAvailable)
+			retryable := &RetryableSetup{
+				Create: func(context.Context, string) (id accessor.ID, e error) {
+					return &dummyIDAccessor{id: 1}, nil
+				},
+				IsWaitForCopy: true,
+				Delete: func(context.Context, string, types.ID) error {
+					return nil
+				},
+				Read: withErrorReadFunc(func(ctx context.Context, zone string, id types.ID) (interface{}, error) {
+					return &dummyIDAccessor{id: 1}, nil
+				}, 3),
+				Options: &Options{
+					RetryCount:                3,
+					ProvisioningRetryInterval: time.Millisecond,
+					DeleteRetryInterval:       time.Millisecond,
+					PollingInterval:           time.Millisecond,
+				},
+			}
+
+			res, err := retryable.Setup(ctx, zone)
+
+			require.NotNil(t, res)
+			require.NoError(t, err)
+		})
+
+		t.Run("max retry count exceeded", func(t *testing.T) {
+			retryable := &RetryableSetup{
+				Create: func(context.Context, string) (id accessor.ID, e error) {
+					return &dummyIDAccessor{id: 1}, nil
+				},
+				IsWaitForCopy: true,
+				Delete: func(context.Context, string, types.ID) error {
+					return nil
+				},
+				Read: withErrorReadFunc(func(ctx context.Context, zone string, id types.ID) (interface{}, error) {
+					return &dummyIDAccessor{id: 1}, nil
+				}, 5),
+				Options: &Options{
+					RetryCount:                3,
+					ProvisioningRetryInterval: time.Millisecond,
+					DeleteRetryInterval:       time.Millisecond,
+					PollingInterval:           time.Millisecond,
+				},
+			}
+
+			res, err := retryable.Setup(ctx, zone)
+
+			require.Nil(t, res)
+			require.Error(t, err)
+			_, ok := err.(MaxRetryCountExceededError)
+			require.True(t, ok)
+		})
+	})
+}
+
+func withErrorReadFunc(readFunc ReadFunc, errCount int) ReadFunc {
+	maxErr := errCount
+	return func(ctx context.Context, zone string, id types.ID) (interface{}, error) {
+		maxErr--
+		if maxErr <= 0 {
+			return &dummyAvailabilityAccessor{available: types.Availabilities.Available}, nil
+		}
+		return &dummyAvailabilityAccessor{available: types.Availabilities.Failed}, nil
+	}
+}

--- a/service/iaas/setup/setup_test.go
+++ b/service/iaas/setup/setup_test.go
@@ -1,0 +1,121 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package setup
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/accessor"
+	"github.com/sacloud/iaas-api-go/helper/power"
+	"github.com/sacloud/iaas-api-go/helper/query"
+	"github.com/sacloud/iaas-api-go/testutil"
+	"github.com/sacloud/iaas-api-go/types"
+)
+
+func TestRetryableSetup(t *testing.T) {
+	var switchID types.ID
+	testZone := testutil.TestZone()
+
+	testutil.RunCRUD(t, &testutil.CRUDTestCase{
+		Parallel: true,
+		SetupAPICallerFunc: func() iaas.APICaller {
+			return testutil.SingletonAPICaller()
+		},
+
+		Setup: func(ctx *testutil.CRUDTestContext, caller iaas.APICaller) error {
+			switchOp := iaas.NewSwitchOp(caller)
+			sw, err := switchOp.Create(ctx, testZone, &iaas.SwitchCreateRequest{Name: "libsacloud-switch-for-util-setup"})
+			if err != nil {
+				return err
+			}
+			switchID = sw.ID
+			return nil
+		},
+
+		Create: &testutil.CRUDTestFunc{
+			Func: func(ctx *testutil.CRUDTestContext, caller iaas.APICaller) (interface{}, error) {
+				nfsOp := iaas.NewNFSOp(caller)
+				nfsSetup := &RetryableSetup{
+					Create: func(ctx context.Context, zone string) (accessor.ID, error) {
+						nfsPlanID, err := query.FindNFSPlanID(ctx, iaas.NewNoteOp(caller), types.NFSPlans.HDD, types.NFSHDDSizes.Size100GB)
+						if err != nil {
+							return nil, err
+						}
+						return nfsOp.Create(ctx, zone, &iaas.NFSCreateRequest{
+							Name:           "libsacloud-nfs-for-util-setup",
+							SwitchID:       switchID,
+							PlanID:         nfsPlanID,
+							IPAddresses:    []string{"192.168.0.11"},
+							NetworkMaskLen: 24,
+							DefaultRoute:   "192.168.0.1",
+						})
+					},
+					Read: func(ctx context.Context, zone string, id types.ID) (interface{}, error) {
+						return nfsOp.Read(ctx, zone, id)
+					},
+					Delete: func(ctx context.Context, zone string, id types.ID) error {
+						return nfsOp.Delete(ctx, zone, id)
+					},
+					IsWaitForCopy: true,
+					IsWaitForUp:   true,
+					Options: &Options{
+						RetryCount: 3,
+					},
+				}
+				if !testutil.IsAccTest() {
+					nfsSetup.Options.ProvisioningRetryInterval = time.Millisecond
+					nfsSetup.Options.DeleteRetryInterval = time.Millisecond
+					nfsSetup.Options.PollingInterval = time.Millisecond
+				}
+
+				return nfsSetup.Setup(ctx, testZone)
+			},
+		},
+		Read: &testutil.CRUDTestFunc{
+			Func: func(ctx *testutil.CRUDTestContext, caller iaas.APICaller) (interface{}, error) {
+				nfsOp := iaas.NewNFSOp(caller)
+				return nfsOp.Read(ctx, testZone, ctx.ID)
+			},
+			CheckFunc: func(t testutil.TestT, ctx *testutil.CRUDTestContext, i interface{}) error {
+				nfs := i.(*iaas.NFS)
+				return testutil.DoAsserts(
+					testutil.AssertEqualFunc(t, types.Availabilities.Available, nfs.Availability, "NFS.Availability"),
+				)
+			},
+		},
+
+		Shutdown: func(ctx *testutil.CRUDTestContext, caller iaas.APICaller) error {
+			return power.ShutdownNFS(ctx, iaas.NewNFSOp(caller), testZone, ctx.ID, true)
+		},
+
+		Delete: &testutil.CRUDTestDeleteFunc{
+			Func: func(ctx *testutil.CRUDTestContext, caller iaas.APICaller) error {
+				nfsOp := iaas.NewNFSOp(caller)
+				if err := nfsOp.Delete(ctx, testZone, ctx.ID); err != nil {
+					return err
+				}
+
+				switchOp := iaas.NewSwitchOp(caller)
+				if err := switchOp.Delete(ctx, testZone, switchID); err != nil {
+					return err
+				}
+				return nil
+			},
+		},
+	})
+}


### PR DESCRIPTION
helper/setupを移植する。
移植に際し、helper/builderで実装していた一部機能(オプション保持機能)も合わせて移植する。