### PR TITLE
service: database

### DIFF
--- a/service/iaas/database/apply_request.go
+++ b/service/iaas/database/apply_request.go
@@ -1,0 +1,110 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"fmt"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/types"
+	databaseBuilder "github.com/sacloud/sacloud-go/service/iaas/database/builder"
+	"github.com/sacloud/sacloud-go/service/validate"
+)
+
+type ApplyRequest struct {
+	Zone string `request:"-" validate:"required"`
+
+	ID                    types.ID `request:"-"`
+	Name                  string   `validate:"required"`
+	Description           string   `validate:"min=0,max=512"`
+	Tags                  types.Tags
+	IconID                types.ID
+	PlanID                types.ID `validate:"required"`
+	SwitchID              types.ID `validate:"required"`
+	IPAddresses           []string `validate:"required,min=1,max=2,dive,ipv4"`
+	NetworkMaskLen        int      `validate:"required,min=1,max=32"`
+	DefaultRoute          string   `validate:"omitempty,ipv4"`
+	Port                  int      `validate:"omitempty,min=1,max=65535"`
+	SourceNetwork         []string `validate:"dive,cidrv4"`
+	DatabaseType          string   `validate:"required,oneof=mariadb postgres"`
+	Username              string   `validate:"required"`
+	Password              string   `validate:"required"`
+	EnableReplication     bool
+	ReplicaUserPassword   string `validate:"required_with=EnableReplication"`
+	EnableWebUI           bool
+	EnableBackup          bool
+	BackupWeekdays        []types.EBackupSpanWeekday `validate:"required_with=EnableBackup,max=7"`
+	BackupStartTimeHour   int                        `validate:"omitempty,min=0,max=23"`
+	BackupStartTimeMinute int                        `validate:"omitempty,oneof=0 15 30 45"`
+	Parameters            map[string]interface{}
+
+	NoWait bool
+}
+
+func (req *ApplyRequest) Validate() error {
+	return validate.Struct(req)
+}
+
+func (req *ApplyRequest) Builder(caller iaas.APICaller) (*databaseBuilder.Builder, error) {
+	replicaUser := ""
+	replicaPassword := ""
+	if req.EnableReplication {
+		replicaUser = "replica"
+		replicaPassword = req.ReplicaUserPassword
+	}
+	builder := &databaseBuilder.Builder{
+		ID:   req.ID,
+		Zone: req.Zone,
+
+		PlanID:         req.PlanID,
+		SwitchID:       req.SwitchID,
+		IPAddresses:    req.IPAddresses,
+		NetworkMaskLen: req.NetworkMaskLen,
+		DefaultRoute:   req.DefaultRoute,
+		Conf: &iaas.DatabaseRemarkDBConfCommon{
+			DatabaseName:     types.RDBMSVersions[types.RDBMSTypeFromString(req.DatabaseType)].Name,
+			DatabaseVersion:  types.RDBMSVersions[types.RDBMSTypeFromString(req.DatabaseType)].Version,
+			DatabaseRevision: types.RDBMSVersions[types.RDBMSTypeFromString(req.DatabaseType)].Revision,
+		},
+		CommonSetting: &iaas.DatabaseSettingCommon{
+			WebUI:           types.ToWebUI(req.EnableWebUI),
+			ServicePort:     req.Port,
+			SourceNetwork:   req.SourceNetwork,
+			DefaultUser:     req.Username,
+			UserPassword:    req.Password,
+			ReplicaUser:     replicaUser,
+			ReplicaPassword: replicaPassword,
+		},
+		Name:        req.Name,
+		Description: req.Description,
+		Tags:        req.Tags,
+		IconID:      req.IconID,
+		Parameters:  req.Parameters,
+		NoWait:      req.NoWait,
+		Client:      databaseBuilder.NewAPIClient(caller),
+	}
+	if req.EnableBackup {
+		builder.BackupSetting = &iaas.DatabaseSettingBackup{
+			Time:      fmt.Sprintf("%02d:%02d", req.BackupStartTimeHour, req.BackupStartTimeMinute),
+			DayOfWeek: req.BackupWeekdays,
+		}
+	}
+	if req.EnableReplication {
+		builder.ReplicationSetting = &iaas.DatabaseReplicationSetting{
+			Model: types.DatabaseReplicationModels.MasterSlave,
+		}
+	}
+	return builder, nil
+}

--- a/service/iaas/database/apply_service.go
+++ b/service/iaas/database/apply_service.go
@@ -1,0 +1,38 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+
+	"github.com/sacloud/iaas-api-go"
+)
+
+func (s *Service) Apply(req *ApplyRequest) (*iaas.Database, error) {
+	return s.ApplyWithContext(context.Background(), req)
+}
+
+func (s *Service) ApplyWithContext(ctx context.Context, req *ApplyRequest) (*iaas.Database, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	builder, err := req.Builder(s.caller)
+	if err != nil {
+		return nil, err
+	}
+
+	return builder.Build(ctx)
+}

--- a/service/iaas/database/apply_test.go
+++ b/service/iaas/database/apply_test.go
@@ -1,0 +1,163 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"testing"
+
+	"github.com/sacloud/iaas-api-go/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateRequest_Validate(t *testing.T) {
+	cases := []struct {
+		in       *ApplyRequest
+		hasError bool
+	}{
+		{
+			in:       &ApplyRequest{},
+			hasError: true,
+		},
+		{
+			// minimum
+			in: &ApplyRequest{
+				Zone:           "tk1a",
+				Name:           "test",
+				PlanID:         types.DatabasePlans.DB10GB,
+				SwitchID:       1,
+				IPAddresses:    []string{"192.168.0.11"},
+				NetworkMaskLen: 16,
+				DefaultRoute:   "192.168.0.1",
+				DatabaseType:   "mariadb",
+				Username:       "hoge",
+				Password:       "pass",
+			},
+			hasError: false,
+		},
+		{
+			// invalid ip
+			in: &ApplyRequest{
+				Zone:           "tk1a",
+				Name:           "test",
+				PlanID:         types.DatabasePlans.DB10GB,
+				SwitchID:       1,
+				IPAddresses:    []string{"192.168.0.999"},
+				NetworkMaskLen: 16,
+				DefaultRoute:   "192.168.0.1",
+				DatabaseType:   "mariadb",
+				Username:       "hoge",
+				Password:       "pass",
+			},
+			hasError: true,
+		},
+		{
+			// invalid ip (out of length)
+			in: &ApplyRequest{
+				Zone:           "tk1a",
+				Name:           "test",
+				PlanID:         types.DatabasePlans.DB10GB,
+				SwitchID:       1,
+				IPAddresses:    []string{"192.168.0.11", "192.168.0.12", "192.168.0.13"},
+				NetworkMaskLen: 16,
+				DefaultRoute:   "192.168.0.1",
+				DatabaseType:   "mariadb",
+				Username:       "hoge",
+				Password:       "pass",
+			},
+			hasError: true,
+		},
+		{
+			// invalid source range
+			in: &ApplyRequest{
+				Zone:           "tk1a",
+				Name:           "test",
+				PlanID:         types.DatabasePlans.DB10GB,
+				SwitchID:       1,
+				IPAddresses:    []string{"192.168.0.11"},
+				NetworkMaskLen: 16,
+				DefaultRoute:   "192.168.0.1",
+				SourceNetwork:  []string{"192.168.0.1"}, // require cidr
+				DatabaseType:   "mariadb",
+				Username:       "hoge",
+				Password:       "pass",
+			},
+			hasError: true,
+		},
+		{
+			// replica user password missing
+			in: &ApplyRequest{
+				Zone:              "tk1a",
+				Name:              "test",
+				PlanID:            types.DatabasePlans.DB10GB,
+				SwitchID:          1,
+				IPAddresses:       []string{"192.168.0.11"},
+				NetworkMaskLen:    16,
+				DefaultRoute:      "192.168.0.1",
+				DatabaseType:      "mariadb",
+				Username:          "hoge",
+				Password:          "pass",
+				EnableReplication: true,
+			},
+			hasError: true,
+		},
+		{
+			// empty plan
+			in: &ApplyRequest{
+				Zone:           "tk1a",
+				Name:           "test",
+				PlanID:         0, // plan is required
+				SwitchID:       1,
+				IPAddresses:    []string{"192.168.0.11"},
+				NetworkMaskLen: 16,
+				DefaultRoute:   "192.168.0.1",
+				DatabaseType:   "mariadb",
+				Username:       "hoge",
+				Password:       "pass",
+			},
+			hasError: true,
+		},
+		{
+			in: &ApplyRequest{
+				Zone:                  "tk1a",
+				Name:                  "test",
+				Description:           "desc",
+				Tags:                  types.Tags{"tag1"},
+				IconID:                1,
+				PlanID:                types.DatabasePlans.DB10GB,
+				SwitchID:              1,
+				IPAddresses:           []string{"192.168.0.11"},
+				NetworkMaskLen:        16,
+				DefaultRoute:          "192.168.0.1",
+				Port:                  5432,
+				SourceNetwork:         []string{"192.168.0.0/24", "192.168.1.0/24"},
+				DatabaseType:          "mariadb",
+				Username:              "hoge",
+				Password:              "pass",
+				EnableReplication:     true,
+				ReplicaUserPassword:   "pass2",
+				EnableWebUI:           true,
+				EnableBackup:          true,
+				BackupWeekdays:        []types.EBackupSpanWeekday{types.BackupSpanWeekdays.Monday},
+				BackupStartTimeHour:   10,
+				BackupStartTimeMinute: 15,
+			},
+			hasError: false,
+		},
+	}
+	for _, tc := range cases {
+		err := tc.in.Validate()
+		require.Equal(t, tc.hasError, err != nil, "with: %#v error: %s", tc.in, err)
+	}
+}

--- a/service/iaas/database/boot_request.go
+++ b/service/iaas/database/boot_request.go
@@ -1,0 +1,31 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"github.com/sacloud/iaas-api-go/types"
+	"github.com/sacloud/sacloud-go/service/validate"
+)
+
+type BootRequest struct {
+	Zone string   `request:"-" validate:"required"`
+	ID   types.ID `request:"-" validate:"required"`
+
+	NoWait bool `request:"-"`
+}
+
+func (req *BootRequest) Validate() error {
+	return validate.Struct(req)
+}

--- a/service/iaas/database/boot_service.go
+++ b/service/iaas/database/boot_service.go
@@ -1,0 +1,38 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/helper/power"
+)
+
+func (s *Service) Boot(req *BootRequest) error {
+	return s.BootWithContext(context.Background(), req)
+}
+
+func (s *Service) BootWithContext(ctx context.Context, req *BootRequest) error {
+	if err := req.Validate(); err != nil {
+		return err
+	}
+
+	client := iaas.NewDatabaseOp(s.caller)
+	if req.NoWait {
+		return client.Boot(ctx, req.Zone, req.ID)
+	}
+	return power.BootDatabase(ctx, client, req.Zone, req.ID)
+}

--- a/service/iaas/database/builder.go
+++ b/service/iaas/database/builder.go
@@ -1,0 +1,57 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/types"
+	databaseBuilder "github.com/sacloud/sacloud-go/service/iaas/database/builder"
+)
+
+func BuilderFromResource(ctx context.Context, caller iaas.APICaller, zone string, id types.ID) (*databaseBuilder.Builder, error) {
+	client := iaas.NewDatabaseOp(caller)
+	current, err := client.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	parameters, err := client.GetParameter(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return &databaseBuilder.Builder{
+		ID:                 current.ID,
+		Zone:               zone,
+		PlanID:             current.PlanID,
+		SwitchID:           current.SwitchID,
+		IPAddresses:        current.IPAddresses,
+		NetworkMaskLen:     current.NetworkMaskLen,
+		DefaultRoute:       current.DefaultRoute,
+		Conf:               current.Conf,
+		CommonSetting:      current.CommonSetting,
+		BackupSetting:      current.BackupSetting,
+		ReplicationSetting: current.ReplicationSetting,
+		Name:               current.Name,
+		Description:        current.Description,
+		Tags:               current.Tags,
+		IconID:             current.IconID,
+		Parameters:         parameters.Settings,
+		SettingsHash:       current.SettingsHash,
+		Client:             databaseBuilder.NewAPIClient(caller),
+	}, nil
+}

--- a/service/iaas/database/builder/api_client.go
+++ b/service/iaas/database/builder/api_client.go
@@ -1,0 +1,29 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package builder
+
+import "github.com/sacloud/iaas-api-go"
+
+// APIClient builderが利用するAPIクライアント
+type APIClient struct {
+	Database iaas.DatabaseAPI
+}
+
+// NewAPIClient builderが利用するAPIクライアントを返す
+func NewAPIClient(caller iaas.APICaller) *APIClient {
+	return &APIClient{
+		Database: iaas.NewDatabaseOp(caller),
+	}
+}

--- a/service/iaas/database/builder/builder.go
+++ b/service/iaas/database/builder/builder.go
@@ -1,0 +1,274 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package builder
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/accessor"
+	"github.com/sacloud/iaas-api-go/defaults"
+	"github.com/sacloud/iaas-api-go/helper/power"
+	"github.com/sacloud/iaas-api-go/types"
+	"github.com/sacloud/sacloud-go/service/iaas/setup"
+)
+
+// Builder データベースの構築を行う
+type Builder struct {
+	ID   types.ID
+	Zone string
+
+	PlanID             types.ID
+	SwitchID           types.ID
+	IPAddresses        []string
+	NetworkMaskLen     int
+	DefaultRoute       string
+	Conf               *iaas.DatabaseRemarkDBConfCommon
+	SourceID           types.ID
+	CommonSetting      *iaas.DatabaseSettingCommon
+	BackupSetting      *iaas.DatabaseSettingBackup
+	ReplicationSetting *iaas.DatabaseReplicationSetting
+	Name               string
+	Description        string
+	Tags               types.Tags
+	IconID             types.ID
+
+	// Parameters RDBMS固有のパラメータ設定
+	//
+	// キーにはiaas.DatabaseParameterMetaのLabelを指定する
+	//   - 例: effective_cache_size: 10
+	Parameters map[string]interface{}
+
+	SettingsHash string
+
+	NoWait bool
+
+	SetupOptions *setup.Options
+	Client       *APIClient
+}
+
+func (b *Builder) init() {
+	if b.SetupOptions == nil {
+		b.SetupOptions = &setup.Options{}
+	}
+	b.SetupOptions.Init()
+}
+
+// Validate 設定値の検証
+func (b *Builder) Validate(ctx context.Context, zone string) error {
+	requiredValues := map[string]bool{
+		"PlanID":         b.PlanID.IsEmpty(),
+		"SwitchID":       b.SwitchID.IsEmpty(),
+		"IPAddresses":    len(b.IPAddresses) == 0,
+		"NetworkMaskLen": b.NetworkMaskLen == 0,
+		"Conf":           b.Conf == nil,
+		"CommonSetting":  b.CommonSetting == nil,
+	}
+	for key, empty := range requiredValues {
+		if empty {
+			return fmt.Errorf("%s is required", key)
+		}
+	}
+	return nil
+}
+
+// Build データベースアプライアンスの構築
+func (b *Builder) Build(ctx context.Context) (*iaas.Database, error) {
+	if b.ID.IsEmpty() {
+		return b.create(ctx, b.Zone)
+	}
+	return b.update(ctx, b.Zone, b.ID)
+}
+
+func (b *Builder) create(ctx context.Context, zone string) (*iaas.Database, error) {
+	b.init()
+
+	if err := b.Validate(ctx, zone); err != nil {
+		return nil, err
+	}
+
+	builder := &setup.RetryableSetup{
+		Create: func(ctx context.Context, zone string) (accessor.ID, error) {
+			return b.Client.Database.Create(ctx, zone, &iaas.DatabaseCreateRequest{
+				PlanID:             b.PlanID,
+				SwitchID:           b.SwitchID,
+				IPAddresses:        b.IPAddresses,
+				NetworkMaskLen:     b.NetworkMaskLen,
+				DefaultRoute:       b.DefaultRoute,
+				Conf:               b.Conf,
+				SourceID:           b.SourceID,
+				CommonSetting:      b.CommonSetting,
+				BackupSetting:      b.BackupSetting,
+				ReplicationSetting: b.ReplicationSetting,
+				Name:               b.Name,
+				Description:        b.Description,
+				Tags:               b.Tags,
+				IconID:             b.IconID,
+			})
+		},
+		Delete: func(ctx context.Context, zone string, id types.ID) error {
+			return b.Client.Database.Delete(ctx, zone, id)
+		},
+		Read: func(ctx context.Context, zone string, id types.ID) (interface{}, error) {
+			return b.Client.Database.Read(ctx, zone, id)
+		},
+		ProvisionBeforeUp: func(ctx context.Context, zone string, id types.ID, _ interface{}) error {
+			if b.NoWait {
+				return nil
+			}
+
+			// [HACK] データベースアプライアンス場合のみ/appliance/:id/statusも考慮する
+			waiter := iaas.WaiterForUp(func() (interface{}, error) {
+				return b.Client.Database.Status(ctx, zone, id)
+			})
+			waiter.(*iaas.StatePollingWaiter).Interval = defaults.DefaultDBStatusPollingInterval // HACK 現状は決め打ち、ユースケースが出たら修正する
+
+			_, err := waiter.WaitForState(ctx)
+			if err != nil {
+				return err
+			}
+
+			if err := b.reconcileDatabaseParameters(ctx, zone, id); err != nil {
+				return err
+			}
+
+			return b.Client.Database.Config(ctx, zone, id)
+		},
+		IsWaitForCopy: !b.NoWait,
+		IsWaitForUp:   !b.NoWait,
+		Options:       b.SetupOptions,
+	}
+
+	result, err := builder.Setup(ctx, zone)
+	var db *iaas.Database
+	if result != nil {
+		db = result.(*iaas.Database)
+	}
+	if err != nil {
+		return db, err
+	}
+
+	// refresh
+	db, err = b.Client.Database.Read(ctx, zone, db.ID)
+	if err != nil {
+		return nil, err
+	}
+	return db, nil
+}
+
+// Update データベースの更新
+func (b *Builder) update(ctx context.Context, zone string, id types.ID) (*iaas.Database, error) {
+	b.init()
+
+	if err := b.Validate(ctx, zone); err != nil {
+		return nil, err
+	}
+
+	// check Database is exists
+	db, err := b.Client.Database.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	isNeedShutdown, err := b.collectUpdateInfo(db)
+	if err != nil {
+		return nil, err
+	}
+
+	isNeedRestart := false
+	if db.InstanceStatus.IsUp() && isNeedShutdown {
+		if b.NoWait {
+			return nil, errors.New("NoWait option is not available due to the need to shut down")
+		}
+
+		isNeedRestart = true
+		if err := power.ShutdownDatabase(ctx, b.Client.Database, zone, id, false); err != nil {
+			return nil, err
+		}
+	}
+
+	_, err = b.Client.Database.Update(ctx, zone, id, &iaas.DatabaseUpdateRequest{
+		Name:               b.Name,
+		Description:        b.Description,
+		Tags:               b.Tags,
+		IconID:             b.IconID,
+		CommonSetting:      b.CommonSetting,
+		BackupSetting:      b.BackupSetting,
+		ReplicationSetting: b.ReplicationSetting,
+		SettingsHash:       b.SettingsHash,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := b.reconcileDatabaseParameters(ctx, zone, id); err != nil {
+		return nil, err
+	}
+	if err := b.Client.Database.Config(ctx, zone, id); err != nil {
+		return nil, err
+	}
+	if isNeedRestart {
+		if err := power.BootDatabase(ctx, b.Client.Database, zone, id); err != nil {
+			return nil, err
+		}
+	}
+
+	// refresh
+	db, err = b.Client.Database.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	return db, err
+}
+
+func (b *Builder) collectUpdateInfo(db *iaas.Database) (isNeedShutdown bool, err error) {
+	isNeedShutdown = b.CommonSetting.ReplicaPassword != db.CommonSetting.ReplicaPassword
+	return
+}
+
+func (b *Builder) reconcileDatabaseParameters(ctx context.Context, zone string, id types.ID) error {
+	parameters, err := b.Client.Database.GetParameter(ctx, zone, id)
+	if err != nil {
+		return err
+	}
+
+	newParameters := make(map[string]interface{})
+	// 既存のパラメータは一旦nullに
+	for k := range parameters.Settings {
+		newParameters[k] = nil
+	}
+
+	for k, v := range b.Parameters {
+		found := false
+		for _, meta := range parameters.MetaInfo {
+			if k == meta.Label {
+				newParameters[meta.Name] = v
+				found = true
+				break
+			}
+		}
+		// kvのキーがラベルではなかったらそのままnmへ
+		if !found {
+			newParameters[k] = v
+		}
+	}
+	if len(newParameters) > 0 {
+		// DatabaseAPI.Configはあとで呼ぶ
+		return b.Client.Database.SetParameter(ctx, zone, id, newParameters)
+	}
+
+	return nil
+}

--- a/service/iaas/database/builder/builder_test.go
+++ b/service/iaas/database/builder/builder_test.go
@@ -1,0 +1,130 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package builder
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/helper/power"
+	"github.com/sacloud/iaas-api-go/testutil"
+	"github.com/sacloud/iaas-api-go/types"
+	"github.com/sacloud/sacloud-go/service/iaas/setup"
+)
+
+func getSetupOption() *setup.Options {
+	if testutil.IsAccTest() {
+		return nil
+	}
+	return &setup.Options{
+		DeleteRetryInterval:       10 * time.Millisecond,
+		ProvisioningRetryInterval: 10 * time.Millisecond,
+		PollingInterval:           10 * time.Millisecond,
+		NICUpdateWaitDuration:     10 * time.Millisecond,
+	}
+}
+
+func TestDatabaseBuilder_Build(t *testing.T) {
+	var switchID types.ID
+	var testZone = testutil.TestZone()
+
+	testutil.RunCRUD(t, &testutil.CRUDTestCase{
+		SetupAPICallerFunc: func() iaas.APICaller {
+			return testutil.SingletonAPICaller()
+		},
+		Parallel:          true,
+		IgnoreStartupWait: true,
+		Setup: func(ctx *testutil.CRUDTestContext, caller iaas.APICaller) error {
+			swOp := iaas.NewSwitchOp(caller)
+
+			sw, err := swOp.Create(ctx, testZone, &iaas.SwitchCreateRequest{
+				Name: testutil.ResourceName("database-builder"),
+			})
+			if err != nil {
+				return err
+			}
+			switchID = sw.ID
+			return nil
+		},
+		Create: &testutil.CRUDTestFunc{
+			Func: func(ctx *testutil.CRUDTestContext, caller iaas.APICaller) (interface{}, error) {
+				builder := &Builder{
+					Zone:           testZone,
+					PlanID:         types.DatabasePlans.DB10GB,
+					SwitchID:       switchID,
+					IPAddresses:    []string{"192.168.0.11"},
+					NetworkMaskLen: 24,
+					DefaultRoute:   "192.168.0.1",
+					Conf: &iaas.DatabaseRemarkDBConfCommon{
+						DatabaseName:     types.RDBMSVersions[types.RDBMSTypesPostgreSQL].Name,
+						DatabaseVersion:  types.RDBMSVersions[types.RDBMSTypesPostgreSQL].Version,
+						DatabaseRevision: types.RDBMSVersions[types.RDBMSTypesPostgreSQL].Revision,
+						DefaultUser:      "builder",
+						UserPassword:     "builder-password-dummy",
+					},
+					CommonSetting: &iaas.DatabaseSettingCommon{
+						DefaultUser:     "builder",
+						UserPassword:    "builder-password-dummy",
+						ReplicaUser:     "",
+						ReplicaPassword: "",
+					},
+					BackupSetting: &iaas.DatabaseSettingBackup{
+						Rotate:    7,
+						Time:      "00:00",
+						DayOfWeek: []types.EBackupSpanWeekday{types.BackupSpanWeekdays.Monday},
+					},
+					ReplicationSetting: &iaas.DatabaseReplicationSetting{},
+					Parameters: map[string]interface{}{
+						"max_connections": 50,
+					},
+					Name:         testutil.ResourceName("database-builder"),
+					Description:  "description",
+					Tags:         types.Tags{"tag1", "tag2"},
+					SetupOptions: getSetupOption(),
+					Client:       NewAPIClient(caller),
+				}
+				return builder.Build(ctx)
+			},
+		},
+		Read: &testutil.CRUDTestFunc{
+			Func: func(ctx *testutil.CRUDTestContext, caller iaas.APICaller) (interface{}, error) {
+				dbOp := iaas.NewDatabaseOp(caller)
+				return dbOp.Read(ctx, testZone, ctx.ID)
+			},
+			CheckFunc: func(t testutil.TestT, ctx *testutil.CRUDTestContext, value interface{}) error {
+				db := value.(*iaas.Database)
+				return testutil.DoAsserts(
+					testutil.AssertNotNilFunc(t, db, "Database"),
+					testutil.AssertNotNilFunc(t, db.Conf, "Database.Conf"),
+				)
+			},
+		},
+		Delete: &testutil.CRUDTestDeleteFunc{
+			Func: func(ctx *testutil.CRUDTestContext, caller iaas.APICaller) error {
+				dbOp := iaas.NewDatabaseOp(caller)
+				return dbOp.Delete(ctx, testZone, ctx.ID)
+			},
+		},
+		Shutdown: func(ctx *testutil.CRUDTestContext, caller iaas.APICaller) error {
+			dbOp := iaas.NewDatabaseOp(caller)
+			return power.ShutdownDatabase(ctx, dbOp, testZone, ctx.ID, true)
+		},
+		Cleanup: func(ctx *testutil.CRUDTestContext, caller iaas.APICaller) error {
+			swOp := iaas.NewSwitchOp(caller)
+			return swOp.Delete(ctx, testZone, switchID)
+		},
+	})
+}

--- a/service/iaas/database/create_request.go
+++ b/service/iaas/database/create_request.go
@@ -1,0 +1,82 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"github.com/sacloud/iaas-api-go/types"
+	"github.com/sacloud/sacloud-go/service/validate"
+)
+
+type CreateRequest struct {
+	Zone string `request:"-" validate:"required"`
+
+	Name                  string `validate:"required"`
+	Description           string `validate:"min=0,max=512"`
+	Tags                  types.Tags
+	IconID                types.ID
+	PlanID                types.ID `validate:"required"`
+	SwitchID              types.ID `validate:"required"`
+	IPAddresses           []string `validate:"required,min=1,max=2,dive,ipv4"`
+	NetworkMaskLen        int      `validate:"required,min=1,max=32"`
+	DefaultRoute          string   `validate:"omitempty,ipv4"`
+	Port                  int      `validate:"omitempty,min=1,max=65535"`
+	SourceNetwork         []string `validate:"omitempty,dive,cidrv4"`
+	DatabaseType          string   `validate:"required,oneof=mariadb postgres"`
+	Username              string   `validate:"required"`
+	Password              string   `validate:"required"`
+	EnableReplication     bool
+	ReplicaUserPassword   string `validate:"required_with=EnableReplication"`
+	EnableWebUI           bool
+	EnableBackup          bool
+	BackupWeekdays        []types.EBackupSpanWeekday `validate:"required_with=EnableBackup,max=7"`
+	BackupStartTimeHour   int                        `validate:"omitempty,min=0,max=23"`
+	BackupStartTimeMinute int                        `validate:"omitempty,oneof=0 15 30 45"`
+	Parameters            map[string]interface{}
+
+	NoWait bool
+}
+
+func (req *CreateRequest) Validate() error {
+	return validate.Struct(req)
+}
+
+func (req *CreateRequest) ApplyRequest() *ApplyRequest {
+	return &ApplyRequest{
+		Zone:                  req.Zone,
+		Name:                  req.Name,
+		Description:           req.Description,
+		Tags:                  req.Tags,
+		IconID:                req.IconID,
+		PlanID:                req.PlanID,
+		SwitchID:              req.SwitchID,
+		IPAddresses:           req.IPAddresses,
+		NetworkMaskLen:        req.NetworkMaskLen,
+		DefaultRoute:          req.DefaultRoute,
+		Port:                  req.Port,
+		SourceNetwork:         req.SourceNetwork,
+		DatabaseType:          req.DatabaseType,
+		Username:              req.Username,
+		Password:              req.Password,
+		EnableReplication:     req.EnableBackup,
+		ReplicaUserPassword:   req.ReplicaUserPassword,
+		EnableWebUI:           req.EnableWebUI,
+		EnableBackup:          req.EnableBackup,
+		BackupWeekdays:        req.BackupWeekdays,
+		BackupStartTimeHour:   req.BackupStartTimeHour,
+		BackupStartTimeMinute: req.BackupStartTimeMinute,
+		Parameters:            req.Parameters,
+		NoWait:                req.NoWait,
+	}
+}

--- a/service/iaas/database/create_service.go
+++ b/service/iaas/database/create_service.go
@@ -1,0 +1,33 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+
+	"github.com/sacloud/iaas-api-go"
+)
+
+func (s *Service) Create(req *CreateRequest) (*iaas.Database, error) {
+	return s.CreateWithContext(context.Background(), req)
+}
+
+func (s *Service) CreateWithContext(ctx context.Context, req *CreateRequest) (*iaas.Database, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	return s.ApplyWithContext(ctx, req.ApplyRequest())
+}

--- a/service/iaas/database/create_test.go
+++ b/service/iaas/database/create_test.go
@@ -1,0 +1,91 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"testing"
+
+	"github.com/sacloud/iaas-api-go/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDatabaseService_convertCreateRequest(t *testing.T) {
+	cases := []struct {
+		in     *CreateRequest
+		expect *ApplyRequest
+	}{
+		{
+			in:     &CreateRequest{},
+			expect: &ApplyRequest{},
+		},
+		{
+			in: &CreateRequest{
+				Zone:                  "is1a",
+				Name:                  "name",
+				Description:           "description",
+				Tags:                  types.Tags{"tag1", "tag2"},
+				IconID:                types.ID(1),
+				PlanID:                types.DatabasePlans.DB30GB,
+				SwitchID:              types.ID(1),
+				IPAddresses:           []string{"192.168.0.101"},
+				NetworkMaskLen:        24,
+				DefaultRoute:          "192.168.0.1",
+				Port:                  5432,
+				SourceNetwork:         []string{"192.168.0.0/24"},
+				DatabaseType:          types.RDBMSTypesPostgreSQL.String(),
+				Username:              "default",
+				Password:              "password1",
+				EnableReplication:     true,
+				ReplicaUserPassword:   "password2",
+				EnableWebUI:           true,
+				EnableBackup:          true,
+				BackupWeekdays:        []types.EBackupSpanWeekday{types.BackupSpanWeekdays.Monday},
+				BackupStartTimeHour:   10,
+				BackupStartTimeMinute: 0,
+				NoWait:                true,
+			},
+			expect: &ApplyRequest{
+				ID:                    0,
+				Zone:                  "is1a",
+				Name:                  "name",
+				Description:           "description",
+				Tags:                  types.Tags{"tag1", "tag2"},
+				IconID:                types.ID(1),
+				PlanID:                types.DatabasePlans.DB30GB,
+				SwitchID:              types.ID(1),
+				IPAddresses:           []string{"192.168.0.101"},
+				NetworkMaskLen:        24,
+				DefaultRoute:          "192.168.0.1",
+				Port:                  5432,
+				SourceNetwork:         []string{"192.168.0.0/24"},
+				DatabaseType:          types.RDBMSTypesPostgreSQL.String(),
+				Username:              "default",
+				Password:              "password1",
+				EnableReplication:     true,
+				ReplicaUserPassword:   "password2",
+				EnableWebUI:           true,
+				EnableBackup:          true,
+				BackupWeekdays:        []types.EBackupSpanWeekday{types.BackupSpanWeekdays.Monday},
+				BackupStartTimeHour:   10,
+				BackupStartTimeMinute: 0,
+				NoWait:                true,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		require.EqualValues(t, tc.expect, tc.in.ApplyRequest())
+	}
+}

--- a/service/iaas/database/delete_request.go
+++ b/service/iaas/database/delete_request.go
@@ -1,0 +1,32 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"github.com/sacloud/iaas-api-go/types"
+	"github.com/sacloud/sacloud-go/service/validate"
+)
+
+type DeleteRequest struct {
+	Zone string   `request:"-" validate:"required"`
+	ID   types.ID `request:"-" validate:"required"`
+
+	FailIfNotFound bool `request:"-"`
+	Force          bool `request:"-"` // trueの場合は電源OFF(強制終了)してから削除
+}
+
+func (req *DeleteRequest) Validate() error {
+	return validate.Struct(req)
+}

--- a/service/iaas/database/delete_service.go
+++ b/service/iaas/database/delete_service.go
@@ -1,0 +1,63 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/helper/wait"
+	"github.com/sacloud/iaas-api-go/types"
+	"github.com/sacloud/sacloud-go/service/iaas/serviceutil"
+)
+
+func (s *Service) Delete(req *DeleteRequest) error {
+	return s.DeleteWithContext(context.Background(), req)
+}
+
+func (s *Service) DeleteWithContext(ctx context.Context, req *DeleteRequest) error {
+	if err := req.Validate(); err != nil {
+		return err
+	}
+
+	client := iaas.NewDatabaseOp(s.caller)
+	target, err := client.Read(ctx, req.Zone, req.ID)
+	if err != nil {
+		return serviceutil.HandleNotFoundError(err, !req.FailIfNotFound)
+	}
+
+	if !req.Force && target.InstanceStatus.IsUp() {
+		return fmt.Errorf("target %s:%q has not yet shut down", req.Zone, req.ID)
+	}
+
+	if target.InstanceStatus.IsUp() {
+		if err := client.Shutdown(ctx, req.Zone, req.ID, &iaas.ShutdownOption{Force: true}); err != nil {
+			return err
+		}
+	}
+
+	// 元の状態がUnknownでなければwait
+	if target.InstanceStatus != types.ServerInstanceStatuses.Unknown {
+		if _, err := wait.UntilDatabaseIsDown(ctx, client, req.Zone, req.ID); err != nil {
+			return err
+		}
+	}
+
+	if err := client.Delete(ctx, req.Zone, req.ID); err != nil {
+		return serviceutil.HandleNotFoundError(err, !req.FailIfNotFound)
+	}
+	return nil
+}

--- a/service/iaas/database/find_request.go
+++ b/service/iaas/database/find_request.go
@@ -1,0 +1,55 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/search"
+	"github.com/sacloud/sacloud-go/pkg/objutil"
+	"github.com/sacloud/sacloud-go/service/iaas/serviceutil"
+	"github.com/sacloud/sacloud-go/service/validate"
+)
+
+type FindRequest struct {
+	Zone string `request:"-" validate:"required"`
+
+	Names []string `request:"-"`
+	Tags  []string `request:"-"`
+
+	Sort  search.SortKeys
+	Count int
+	From  int
+}
+
+func (req *FindRequest) Validate() error {
+	return validate.Struct(req)
+}
+
+func (req *FindRequest) ToRequestParameter() (*iaas.FindCondition, error) {
+	condition := &iaas.FindCondition{
+		Filter: map[search.FilterKey]interface{}{},
+	}
+	if err := serviceutil.RequestConvertTo(req, condition); err != nil {
+		return nil, err
+	}
+
+	if !objutil.IsEmpty(req.Names) {
+		condition.Filter[search.Key("Name")] = search.AndEqual(req.Names...)
+	}
+	if !objutil.IsEmpty(req.Tags) {
+		condition.Filter[search.Key("Tags.Name")] = search.TagsAndEqual(req.Tags...)
+	}
+	return condition, nil
+}

--- a/service/iaas/database/find_service.go
+++ b/service/iaas/database/find_service.go
@@ -1,0 +1,43 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+
+	"github.com/sacloud/iaas-api-go"
+)
+
+func (s *Service) Find(req *FindRequest) ([]*iaas.Database, error) {
+	return s.FindWithContext(context.Background(), req)
+}
+
+func (s *Service) FindWithContext(ctx context.Context, req *FindRequest) ([]*iaas.Database, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	params, err := req.ToRequestParameter()
+	if err != nil {
+		return nil, err
+	}
+
+	client := iaas.NewDatabaseOp(s.caller)
+	found, err := client.Find(ctx, req.Zone, params)
+	if err != nil {
+		return nil, err
+	}
+	return found.Databases, nil
+}

--- a/service/iaas/database/list_parameter.go
+++ b/service/iaas/database/list_parameter.go
@@ -1,0 +1,23 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import "github.com/sacloud/iaas-api-go"
+
+type Parameter struct {
+	Key   string
+	Value interface{}
+	Meta  *iaas.DatabaseParameterMeta
+}

--- a/service/iaas/database/list_parameter_request.go
+++ b/service/iaas/database/list_parameter_request.go
@@ -1,0 +1,29 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"github.com/sacloud/iaas-api-go/types"
+	"github.com/sacloud/sacloud-go/service/validate"
+)
+
+type ListParameterRequest struct {
+	Zone string   `request:"-" validate:"required"`
+	ID   types.ID `request:"-" validate:"required"`
+}
+
+func (req *ListParameterRequest) Validate() error {
+	return validate.Struct(req)
+}

--- a/service/iaas/database/list_parameter_service.go
+++ b/service/iaas/database/list_parameter_service.go
@@ -1,0 +1,52 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+
+	"github.com/sacloud/iaas-api-go"
+)
+
+func (s *Service) ListParameter(req *ListParameterRequest) ([]*Parameter, error) {
+	return s.ListParameterWithContext(context.Background(), req)
+}
+
+func (s *Service) ListParameterWithContext(ctx context.Context, req *ListParameterRequest) ([]*Parameter, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	client := iaas.NewDatabaseOp(s.caller)
+	parameters, err := client.GetParameter(ctx, req.Zone, req.ID)
+	if err != nil {
+		return nil, err
+	}
+	var results []*Parameter
+	for _, p := range parameters.MetaInfo {
+		var setting interface{}
+		for k, v := range parameters.Settings {
+			if p.Name == k {
+				setting = v
+				break
+			}
+		}
+		results = append(results, &Parameter{
+			Key:   p.Label,
+			Value: setting,
+			Meta:  p,
+		})
+	}
+	return results, nil
+}

--- a/service/iaas/database/monitor_cpu_request.go
+++ b/service/iaas/database/monitor_cpu_request.go
@@ -1,0 +1,34 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"time"
+
+	"github.com/sacloud/iaas-api-go/types"
+	"github.com/sacloud/sacloud-go/service/validate"
+)
+
+type MonitorCPURequest struct {
+	Zone string   `request:"-" validate:"required"`
+	ID   types.ID `request:"-" validate:"required"`
+
+	Start time.Time
+	End   time.Time
+}
+
+func (req *MonitorCPURequest) Validate() error {
+	return validate.Struct(req)
+}

--- a/service/iaas/database/monitor_cpu_service.go
+++ b/service/iaas/database/monitor_cpu_service.go
@@ -1,0 +1,44 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/sacloud-go/service/iaas/serviceutil"
+)
+
+func (s *Service) MonitorCPU(req *MonitorCPURequest) ([]*iaas.MonitorCPUTimeValue, error) {
+	return s.MonitorCPUWithContext(context.Background(), req)
+}
+
+func (s *Service) MonitorCPUWithContext(ctx context.Context, req *MonitorCPURequest) ([]*iaas.MonitorCPUTimeValue, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	client := iaas.NewDatabaseOp(s.caller)
+	cond, err := serviceutil.MonitorCondition(req.Start, req.End)
+	if err != nil {
+		return nil, err
+	}
+
+	values, err := client.MonitorCPU(ctx, req.Zone, req.ID, cond)
+	if err != nil {
+		return nil, err
+	}
+	return values.Values, nil
+}

--- a/service/iaas/database/monitor_database_request.go
+++ b/service/iaas/database/monitor_database_request.go
@@ -1,0 +1,34 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"time"
+
+	"github.com/sacloud/iaas-api-go/types"
+	"github.com/sacloud/sacloud-go/service/validate"
+)
+
+type MonitorDatabaseRequest struct {
+	Zone string   `request:"-" validate:"required"`
+	ID   types.ID `request:"-" validate:"required"`
+
+	Start time.Time
+	End   time.Time
+}
+
+func (req *MonitorDatabaseRequest) Validate() error {
+	return validate.Struct(req)
+}

--- a/service/iaas/database/monitor_database_service.go
+++ b/service/iaas/database/monitor_database_service.go
@@ -1,0 +1,44 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/sacloud-go/service/iaas/serviceutil"
+)
+
+func (s *Service) MonitorDatabase(req *MonitorDatabaseRequest) ([]*iaas.MonitorDatabaseValue, error) {
+	return s.MonitorDatabaseWithContext(context.Background(), req)
+}
+
+func (s *Service) MonitorDatabaseWithContext(ctx context.Context, req *MonitorDatabaseRequest) ([]*iaas.MonitorDatabaseValue, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	client := iaas.NewDatabaseOp(s.caller)
+	cond, err := serviceutil.MonitorCondition(req.Start, req.End)
+	if err != nil {
+		return nil, err
+	}
+
+	values, err := client.MonitorDatabase(ctx, req.Zone, req.ID, cond)
+	if err != nil {
+		return nil, err
+	}
+	return values.Values, nil
+}

--- a/service/iaas/database/monitor_disk_request.go
+++ b/service/iaas/database/monitor_disk_request.go
@@ -1,0 +1,34 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"time"
+
+	"github.com/sacloud/iaas-api-go/types"
+	"github.com/sacloud/sacloud-go/service/validate"
+)
+
+type MonitorDiskRequest struct {
+	Zone string   `request:"-" validate:"required"`
+	ID   types.ID `request:"-" validate:"required"`
+
+	Start time.Time
+	End   time.Time
+}
+
+func (req *MonitorDiskRequest) Validate() error {
+	return validate.Struct(req)
+}

--- a/service/iaas/database/monitor_disk_service.go
+++ b/service/iaas/database/monitor_disk_service.go
@@ -1,0 +1,44 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/sacloud-go/service/iaas/serviceutil"
+)
+
+func (s *Service) MonitorDisk(req *MonitorDiskRequest) ([]*iaas.MonitorDiskValue, error) {
+	return s.MonitorDiskWithContext(context.Background(), req)
+}
+
+func (s *Service) MonitorDiskWithContext(ctx context.Context, req *MonitorDiskRequest) ([]*iaas.MonitorDiskValue, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	client := iaas.NewDatabaseOp(s.caller)
+	cond, err := serviceutil.MonitorCondition(req.Start, req.End)
+	if err != nil {
+		return nil, err
+	}
+
+	values, err := client.MonitorDisk(ctx, req.Zone, req.ID, cond)
+	if err != nil {
+		return nil, err
+	}
+	return values.Values, nil
+}

--- a/service/iaas/database/monitor_interface_request.go
+++ b/service/iaas/database/monitor_interface_request.go
@@ -1,0 +1,34 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"time"
+
+	"github.com/sacloud/iaas-api-go/types"
+	"github.com/sacloud/sacloud-go/service/validate"
+)
+
+type MonitorInterfaceRequest struct {
+	Zone string   `request:"-" validate:"required"`
+	ID   types.ID `request:"-" validate:"required"`
+
+	Start time.Time
+	End   time.Time
+}
+
+func (req *MonitorInterfaceRequest) Validate() error {
+	return validate.Struct(req)
+}

--- a/service/iaas/database/monitor_interface_service.go
+++ b/service/iaas/database/monitor_interface_service.go
@@ -1,0 +1,44 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/sacloud-go/service/iaas/serviceutil"
+)
+
+func (s *Service) MonitorInterface(req *MonitorInterfaceRequest) ([]*iaas.MonitorInterfaceValue, error) {
+	return s.MonitorInterfaceWithContext(context.Background(), req)
+}
+
+func (s *Service) MonitorInterfaceWithContext(ctx context.Context, req *MonitorInterfaceRequest) ([]*iaas.MonitorInterfaceValue, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	client := iaas.NewDatabaseOp(s.caller)
+	cond, err := serviceutil.MonitorCondition(req.Start, req.End)
+	if err != nil {
+		return nil, err
+	}
+
+	values, err := client.MonitorInterface(ctx, req.Zone, req.ID, cond)
+	if err != nil {
+		return nil, err
+	}
+	return values.Values, nil
+}

--- a/service/iaas/database/read_request.go
+++ b/service/iaas/database/read_request.go
@@ -1,0 +1,29 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"github.com/sacloud/iaas-api-go/types"
+	"github.com/sacloud/sacloud-go/service/validate"
+)
+
+type ReadRequest struct {
+	Zone string   `request:"-" validate:"required"`
+	ID   types.ID `request:"-" validate:"required"`
+}
+
+func (req *ReadRequest) Validate() error {
+	return validate.Struct(req)
+}

--- a/service/iaas/database/read_service.go
+++ b/service/iaas/database/read_service.go
@@ -1,0 +1,33 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+
+	"github.com/sacloud/iaas-api-go"
+)
+
+func (s *Service) Read(req *ReadRequest) (*iaas.Database, error) {
+	return s.ReadWithContext(context.Background(), req)
+}
+
+func (s *Service) ReadWithContext(ctx context.Context, req *ReadRequest) (*iaas.Database, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	client := iaas.NewDatabaseOp(s.caller)
+	return client.Read(ctx, req.Zone, req.ID)
+}

--- a/service/iaas/database/reset_request.go
+++ b/service/iaas/database/reset_request.go
@@ -1,0 +1,29 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"github.com/sacloud/iaas-api-go/types"
+	"github.com/sacloud/sacloud-go/service/validate"
+)
+
+type ResetRequest struct {
+	Zone string   `request:"-" validate:"required"`
+	ID   types.ID `request:"-" validate:"required"`
+}
+
+func (req *ResetRequest) Validate() error {
+	return validate.Struct(req)
+}

--- a/service/iaas/database/reset_service.go
+++ b/service/iaas/database/reset_service.go
@@ -1,0 +1,34 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+
+	"github.com/sacloud/iaas-api-go"
+)
+
+func (s *Service) Reset(req *ResetRequest) error {
+	return s.ResetWithContext(context.Background(), req)
+}
+
+func (s *Service) ResetWithContext(ctx context.Context, req *ResetRequest) error {
+	if err := req.Validate(); err != nil {
+		return err
+	}
+
+	client := iaas.NewDatabaseOp(s.caller)
+	return client.Reset(ctx, req.Zone, req.ID)
+}

--- a/service/iaas/database/service.go
+++ b/service/iaas/database/service.go
@@ -1,0 +1,27 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import "github.com/sacloud/iaas-api-go"
+
+// Service provides a high-level API of for Database
+type Service struct {
+	caller iaas.APICaller
+}
+
+// New returns new service instance of Database
+func New(caller iaas.APICaller) *Service {
+	return &Service{caller: caller}
+}

--- a/service/iaas/database/shutdown_request.go
+++ b/service/iaas/database/shutdown_request.go
@@ -1,0 +1,32 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"github.com/sacloud/iaas-api-go/types"
+	"github.com/sacloud/sacloud-go/service/validate"
+)
+
+type ShutdownRequest struct {
+	Zone string   `request:"-" validate:"required"`
+	ID   types.ID `request:"-" validate:"required"`
+
+	NoWait        bool `request:"-"`
+	ForceShutdown bool `request:"-"`
+}
+
+func (req *ShutdownRequest) Validate() error {
+	return validate.Struct(req)
+}

--- a/service/iaas/database/shutdown_service.go
+++ b/service/iaas/database/shutdown_service.go
@@ -1,0 +1,38 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/helper/power"
+)
+
+func (s *Service) Shutdown(req *ShutdownRequest) error {
+	return s.ShutdownWithContext(context.Background(), req)
+}
+
+func (s *Service) ShutdownWithContext(ctx context.Context, req *ShutdownRequest) error {
+	if err := req.Validate(); err != nil {
+		return err
+	}
+
+	client := iaas.NewDatabaseOp(s.caller)
+	if req.NoWait {
+		return client.Shutdown(ctx, req.Zone, req.ID, &iaas.ShutdownOption{Force: req.ForceShutdown})
+	}
+	return power.ShutdownDatabase(ctx, client, req.Zone, req.ID, req.ForceShutdown)
+}

--- a/service/iaas/database/update_request.go
+++ b/service/iaas/database/update_request.go
@@ -1,0 +1,149 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/types"
+	"github.com/sacloud/sacloud-go/service/iaas/serviceutil"
+	"github.com/sacloud/sacloud-go/service/validate"
+)
+
+type UpdateRequest struct {
+	Zone string   `validate:"required"`
+	ID   types.ID `validate:"required"`
+
+	Name        *string     `request:",omitempty" validate:"omitempty,min=1"`
+	Description *string     `request:",omitempty" validate:"omitempty,min=1,max=512"`
+	Tags        *types.Tags `request:",omitempty"`
+	IconID      *types.ID   `request:",omitempty"`
+
+	SourceNetwork         *[]string                   `request:",omitempty" validate:"omitempty,dive,cidrv4"`
+	EnableReplication     *bool                       `request:",omitempty"`
+	ReplicaUserPassword   *string                     `request:",omitempty" validate:"omitempty,required_with=EnableReplication"`
+	EnableWebUI           *bool                       `request:",omitempty"`
+	EnableBackup          *bool                       `request:",omitempty"`
+	BackupWeekdays        *[]types.EBackupSpanWeekday `request:",omitempty" validate:"omitempty,required_with=EnableBackup,max=7"`
+	BackupStartTimeHour   *int                        `request:",omitempty" validate:"omitempty,min=0,max=23"`
+	BackupStartTimeMinute *int                        `request:",omitempty" validate:"omitempty,oneof=0 15 30 45"`
+	Parameters            *map[string]interface{}     `request:",omitempty"`
+
+	SettingsHash string
+	NoWait       bool
+}
+
+func (req *UpdateRequest) Validate() error {
+	return validate.Struct(req)
+}
+
+func (req *UpdateRequest) ApplyRequest(ctx context.Context, caller iaas.APICaller) (*ApplyRequest, error) {
+	dbOp := iaas.NewDatabaseOp(caller)
+	current, err := dbOp.Read(ctx, req.Zone, req.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	if current.Availability != types.Availabilities.Available {
+		return nil, fmt.Errorf("target has invalid Availability: Zone=%s ID=%s Availability=%v", req.Zone, req.ID.String(), current.Availability)
+	}
+
+	var bkHour, bkMinute int
+	var bkWeekdays []types.EBackupSpanWeekday
+	if current.BackupSetting != nil {
+		bkWeekdays = current.BackupSetting.DayOfWeek
+		if current.BackupSetting.Time != "" {
+			timeStrings := strings.Split(current.BackupSetting.Time, ":")
+			if len(timeStrings) == 2 {
+				hour, err := strconv.ParseInt(timeStrings[0], 10, 64)
+				if err != nil {
+					return nil, err
+				}
+				bkHour = int(hour)
+
+				minute, err := strconv.ParseInt(timeStrings[1], 10, 64)
+				if err != nil {
+					return nil, err
+				}
+				bkMinute = int(minute)
+			}
+		}
+	}
+
+	applyRequest := &ApplyRequest{
+		Zone:                  req.Zone,
+		ID:                    req.ID,
+		Name:                  current.Name,
+		Description:           current.Description,
+		Tags:                  current.Tags,
+		IconID:                current.IconID,
+		PlanID:                current.PlanID,
+		SwitchID:              current.SwitchID,
+		IPAddresses:           current.IPAddresses,
+		NetworkMaskLen:        current.NetworkMaskLen,
+		DefaultRoute:          current.DefaultRoute,
+		Port:                  current.CommonSetting.ServicePort,
+		SourceNetwork:         current.CommonSetting.SourceNetwork,
+		DatabaseType:          current.Conf.DatabaseName,
+		Username:              current.CommonSetting.DefaultUser,
+		Password:              current.CommonSetting.UserPassword,
+		EnableReplication:     current.ReplicationSetting != nil,
+		ReplicaUserPassword:   current.CommonSetting.ReplicaPassword,
+		EnableWebUI:           current.CommonSetting.WebUI.Bool(),
+		EnableBackup:          current.BackupSetting != nil,
+		BackupWeekdays:        bkWeekdays,
+		BackupStartTimeHour:   bkHour,
+		BackupStartTimeMinute: bkMinute,
+		NoWait:                false,
+	}
+
+	if err := serviceutil.RequestConvertTo(req, applyRequest); err != nil {
+		return nil, err
+	}
+
+	// パラメータは手動マージ
+	parameter, err := dbOp.GetParameter(ctx, req.Zone, req.ID)
+	if err != nil {
+		return nil, err
+	}
+	// パラメータ設定をLabelをキーにするように正規化
+	ps := make(map[string]interface{})
+	for k, v := range parameter.Settings {
+		for _, meta := range parameter.MetaInfo {
+			if meta.Name == k {
+				ps[meta.Label] = v
+			}
+		}
+	}
+	if req.Parameters != nil {
+		for k, v := range *req.Parameters {
+			key := k
+			for _, meta := range parameter.MetaInfo {
+				if meta.Name == key {
+					key = meta.Label
+					break
+				}
+			}
+			ps[key] = v
+		}
+	}
+	applyRequest.Parameters = ps
+
+	return applyRequest, nil
+}

--- a/service/iaas/database/update_service.go
+++ b/service/iaas/database/update_service.go
@@ -1,0 +1,39 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sacloud/iaas-api-go"
+)
+
+func (s *Service) Update(req *UpdateRequest) (*iaas.Database, error) {
+	return s.UpdateWithContext(context.Background(), req)
+}
+
+func (s *Service) UpdateWithContext(ctx context.Context, req *UpdateRequest) (*iaas.Database, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	applyRequest, err := req.ApplyRequest(ctx, s.caller)
+	if err != nil {
+		return nil, fmt.Errorf("processing request parameter failed: %s", err)
+	}
+
+	return s.ApplyWithContext(ctx, applyRequest)
+}

--- a/service/iaas/database/update_test.go
+++ b/service/iaas/database/update_test.go
@@ -1,0 +1,197 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/helper/wait"
+	"github.com/sacloud/iaas-api-go/testutil"
+	"github.com/sacloud/iaas-api-go/types"
+	"github.com/sacloud/sacloud-go/pkg/pointer"
+	databaseBuilder "github.com/sacloud/sacloud-go/service/iaas/database/builder"
+	"github.com/sacloud/sacloud-go/service/iaas/setup"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDatabaseService_convertUpdateRequest(t *testing.T) {
+	if testutil.IsAccTest() {
+		t.Skip("This test runs only without TESTACC=1")
+	}
+	ctx := context.Background()
+	zone := testutil.TestZone()
+	name := testutil.ResourceName("database-service-update")
+	caller := testutil.SingletonAPICaller()
+
+	sw, err := iaas.NewSwitchOp(caller).Create(ctx, zone, &iaas.SwitchCreateRequest{Name: name})
+	if err != nil {
+		t.Fatal(err)
+	}
+	builder := &databaseBuilder.Builder{
+		Zone:           zone,
+		PlanID:         types.DatabasePlans.DB10GB,
+		SwitchID:       sw.ID,
+		IPAddresses:    []string{"192.168.0.101"},
+		NetworkMaskLen: 24,
+		DefaultRoute:   "192.168.0.1",
+		Conf: &iaas.DatabaseRemarkDBConfCommon{
+			DatabaseName:     types.RDBMSVersions[types.RDBMSTypesPostgreSQL].Name,
+			DatabaseVersion:  types.RDBMSVersions[types.RDBMSTypesPostgreSQL].Version,
+			DatabaseRevision: types.RDBMSVersions[types.RDBMSTypesPostgreSQL].Revision,
+		},
+		SourceID: 0,
+		CommonSetting: &iaas.DatabaseSettingCommon{
+			WebUI:           types.ToWebUI(true),
+			ServicePort:     5432,
+			SourceNetwork:   []string{"192.168.0.0/24"},
+			DefaultUser:     "default",
+			UserPassword:    "password1",
+			ReplicaUser:     "replica",
+			ReplicaPassword: "password2",
+		},
+		BackupSetting: &iaas.DatabaseSettingBackup{
+			Rotate:    0,
+			Time:      "10:00",
+			DayOfWeek: []types.EBackupSpanWeekday{types.BackupSpanWeekdays.Monday},
+		},
+		ReplicationSetting: &iaas.DatabaseReplicationSetting{
+			Model: types.DatabaseReplicationModels.MasterSlave,
+		},
+		Name:         name,
+		Description:  "description",
+		Tags:         types.Tags{"tag1", "tag2"},
+		SettingsHash: "",
+		NoWait:       false,
+		Parameters: map[string]interface{}{
+			"max_connections": float64(100),
+		},
+		SetupOptions: &setup.Options{
+			BootAfterBuild:        true,
+			NICUpdateWaitDuration: time.Millisecond,
+			PollingInterval:       time.Millisecond,
+		},
+		Client: databaseBuilder.NewAPIClient(caller),
+	}
+	db, err := builder.Build(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		dbOp := iaas.NewDatabaseOp(caller)
+		if err := dbOp.Shutdown(ctx, zone, db.ID, &iaas.ShutdownOption{Force: true}); err != nil {
+			return
+		}
+		if _, err := wait.UntilDatabaseIsDown(ctx, dbOp, zone, db.ID); err != nil {
+			return
+		}
+		if err := dbOp.Delete(ctx, zone, db.ID); err != nil {
+			return
+		}
+		iaas.NewSwitchOp(caller).Delete(ctx, zone, sw.ID) // nolint
+	}()
+
+	cases := []struct {
+		in     *UpdateRequest
+		expect *ApplyRequest
+	}{
+		{
+			in: &UpdateRequest{
+				Zone:   zone,
+				ID:     db.ID,
+				Name:   pointer.NewString(db.Name + "-upd"),
+				NoWait: true,
+			},
+			expect: &ApplyRequest{
+				Zone:                  zone,
+				ID:                    db.ID,
+				Name:                  db.Name + "-upd",
+				Description:           "description",
+				Tags:                  types.Tags{"tag1", "tag2"},
+				PlanID:                types.DatabasePlans.DB10GB,
+				SwitchID:              sw.ID,
+				IPAddresses:           []string{"192.168.0.101"},
+				NetworkMaskLen:        24,
+				DefaultRoute:          "192.168.0.1",
+				Port:                  5432,
+				SourceNetwork:         []string{"192.168.0.0/24"},
+				DatabaseType:          types.RDBMSTypesPostgreSQL.String(),
+				Username:              "default",
+				Password:              "password1",
+				EnableReplication:     true,
+				ReplicaUserPassword:   "password2",
+				EnableWebUI:           true,
+				EnableBackup:          true,
+				BackupWeekdays:        []types.EBackupSpanWeekday{types.BackupSpanWeekdays.Monday},
+				BackupStartTimeHour:   10,
+				BackupStartTimeMinute: 0,
+				Parameters: map[string]interface{}{
+					"max_connections": float64(100),
+				},
+				NoWait: true,
+			},
+		},
+		{
+			in: &UpdateRequest{
+				Zone:              zone,
+				ID:                db.ID,
+				EnableReplication: pointer.NewBool(false),
+				EnableBackup:      pointer.NewBool(false),
+				Parameters: &map[string]interface{}{
+					"work_mem": float64(4096),
+				},
+				NoWait: true,
+			},
+			expect: &ApplyRequest{
+				Zone:                  zone,
+				ID:                    db.ID,
+				Name:                  db.Name,
+				Description:           "description",
+				Tags:                  types.Tags{"tag1", "tag2"},
+				PlanID:                types.DatabasePlans.DB10GB,
+				SwitchID:              sw.ID,
+				IPAddresses:           []string{"192.168.0.101"},
+				NetworkMaskLen:        24,
+				DefaultRoute:          "192.168.0.1",
+				Port:                  5432,
+				SourceNetwork:         []string{"192.168.0.0/24"},
+				DatabaseType:          types.RDBMSTypesPostgreSQL.String(),
+				Username:              "default",
+				Password:              "password1",
+				EnableReplication:     false,
+				ReplicaUserPassword:   "password2",
+				EnableWebUI:           true,
+				EnableBackup:          false,
+				BackupWeekdays:        []types.EBackupSpanWeekday{types.BackupSpanWeekdays.Monday},
+				BackupStartTimeHour:   10,
+				BackupStartTimeMinute: 0,
+				Parameters: map[string]interface{}{
+					"max_connections": float64(100),
+					"work_mem":        float64(4096),
+				},
+				NoWait: true,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		got, err := tc.in.ApplyRequest(ctx, caller)
+		require.NoError(t, err)
+		require.EqualValues(t, tc.expect, got)
+	}
+}

--- a/service/iaas/database/wait_boot_request.go
+++ b/service/iaas/database/wait_boot_request.go
@@ -1,0 +1,29 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"github.com/sacloud/iaas-api-go/types"
+	"github.com/sacloud/sacloud-go/service/validate"
+)
+
+type WaitBootRequest struct {
+	Zone string   `request:"-" validate:"required"`
+	ID   types.ID `request:"-" validate:"required"`
+}
+
+func (req *WaitBootRequest) Validate() error {
+	return validate.Struct(req)
+}

--- a/service/iaas/database/wait_boot_service.go
+++ b/service/iaas/database/wait_boot_service.go
@@ -1,0 +1,36 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/helper/wait"
+)
+
+func (s *Service) WaitBoot(req *WaitBootRequest) error {
+	return s.WaitBootWithContext(context.Background(), req)
+}
+
+func (s *Service) WaitBootWithContext(ctx context.Context, req *WaitBootRequest) error {
+	if err := req.Validate(); err != nil {
+		return err
+	}
+
+	client := iaas.NewDatabaseOp(s.caller)
+	_, err := wait.UntilDatabaseIsUp(ctx, client, req.Zone, req.ID)
+	return err
+}

--- a/service/iaas/database/wait_shutdown_request.go
+++ b/service/iaas/database/wait_shutdown_request.go
@@ -1,0 +1,29 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"github.com/sacloud/iaas-api-go/types"
+	"github.com/sacloud/sacloud-go/service/validate"
+)
+
+type WaitShutdownRequest struct {
+	Zone string   `request:"-" validate:"required"`
+	ID   types.ID `request:"-" validate:"required"`
+}
+
+func (req *WaitShutdownRequest) Validate() error {
+	return validate.Struct(req)
+}

--- a/service/iaas/database/wait_shutdown_service.go
+++ b/service/iaas/database/wait_shutdown_service.go
@@ -1,0 +1,36 @@
+// Copyright 2022 The sacloud/sacloud-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/helper/wait"
+)
+
+func (s *Service) WaitShutdown(req *WaitShutdownRequest) error {
+	return s.WaitShutdownWithContext(context.Background(), req)
+}
+
+func (s *Service) WaitShutdownWithContext(ctx context.Context, req *WaitShutdownRequest) error {
+	if err := req.Validate(); err != nil {
+		return err
+	}
+
+	client := iaas.NewDatabaseOp(s.caller)
+	_, err := wait.UntilDatabaseIsDown(ctx, client, req.Zone, req.ID)
+	return err
+}

--- a/service/iaas/setup/options.go
+++ b/service/iaas/setup/options.go
@@ -59,7 +59,7 @@ type Options struct {
 	PollingInterval time.Duration
 }
 
-func (o *Options) init() {
+func (o *Options) Init() {
 	if o.NICUpdateWaitDuration == time.Duration(0) {
 		o.NICUpdateWaitDuration = DefaultNICUpdateWaitDuration
 	}

--- a/service/iaas/setup/retryable_setup.go
+++ b/service/iaas/setup/retryable_setup.go
@@ -124,7 +124,7 @@ func (r *RetryableSetup) init() {
 	if r.Options == nil {
 		r.Options = &Options{}
 	}
-	r.Options.init()
+	r.Options.Init()
 }
 
 func (r *RetryableSetup) createResource(ctx context.Context, zone string) (accessor.ID, error) {


### PR DESCRIPTION
Note: libsacloudのhelper/service/databaseにはhelper/builderを移行するまでの経過措置として独自のBuilderの実装があったが、今回の移植に伴い廃止しhelper/builderに統合〜service/iaas/database/builderへ移植した。